### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Experimental-Control-Software
 A GUI written in Python for experiment control using ADwin Gold (Jaeger Messtechnik) and Pixelfly CCD cameras (PCO)
+
+


### PR DESCRIPTION
In actual GUI one can now select between one of two PCO Pixelfly cameras, either the Pixelfly qe (whose Python interface is based on SDK Version 1.07) or the (newer) Pixelfly USB (whose Python interface is based on SDK Version 1.22).

This is the first commit on 29th of Oct. 2017.